### PR TITLE
added example axis labels as part of layout

### DIFF
--- a/docs/pages/components/plot.md
+++ b/docs/pages/components/plot.md
@@ -2418,6 +2418,18 @@ layout: component
             line: { color: '#7F7F7F' },
         },
     ]
+    document.getElementById('example').layout = {
+        title: 'Company Stock Price',
+            xaxis: {
+                title: 'Time',
+                showgrid: false,
+                zeroline: false
+            },
+            yaxis: {
+                title: 'Stock Price',
+                showline: false
+            }
+        };
 </script>
 ```
 

--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { deleteSync } from 'del'
 import prettier from 'prettier'
-import { default as prettierConfig } from '@gesdisc/prettier-config/index.json' assert { type: 'json' }
+import { default as prettierConfig } from '@gesdisc/prettier-config/index.json' with { type: 'json' }
 import { getAllComponents } from './shared.js'
 
 const { outdir } = commandLineArgs({ name: 'outdir', type: String })


### PR DESCRIPTION
Not sure how much needs to be added here, but with Javascript, component layout property can be used to customize the title and axis of the graph. In addition, there was a modification to use "with" instead of "assert" to work with newer versions of Node. If this breaks anyone's setup, this can get reverted back, even though I haven't had bad experiences with this change.