### PR TITLE
Feature/gu UI 3497 combobox behavior

### DIFF
--- a/src/components/time-series/time-series.component.ts
+++ b/src/components/time-series/time-series.component.ts
@@ -389,6 +389,7 @@ export default class TerraTimeSeries extends TerraElement {
                     ? `${this.collection}_${this.variable}`
                     : nothing}
                 .bearerToken=${this.bearerToken ?? null}
+                .useTags=${true}
                 @terra-combobox-change="${this.#handleVariableChange}"
             ></terra-variable-combobox>
 

--- a/src/components/variable-combobox/lib.ts
+++ b/src/components/variable-combobox/lib.ts
@@ -18,6 +18,7 @@ function renderSearchResult(listItem: GroupedListItem, index: number) {
                             id="listbox-option-${index}.${subIndex}"
                             role="option"
                             class="listbox-option"
+                            data-name=${variable.name}
                             data-long-name=${variable.longName}
                             data-event-detail=${variable.eventDetail}
                         >

--- a/src/components/variable-combobox/variable-combobox.styles.ts
+++ b/src/components/variable-combobox/variable-combobox.styles.ts
@@ -50,6 +50,39 @@ export default css`
         flex-wrap: wrap;
     }
 
+    .tag-container {
+        block-size: var(--terra-block-size, 2.25rem);
+        position: absolute;
+        top: 2.25rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-content: center;
+        padding-inline-start: 0.5rem;
+    }
+
+    .tag {
+        --terra-button-height-small: 1.25rem;
+        --terra-spacing-small: 0.5rem;
+    }
+
+    .tag:hover .tag-icon,
+    .tag:active .tag-icon,
+    .tag:focus .tag-icon {
+        transform: scale(1.125);
+        color: var(--terra-color-nasa-red-shade);
+        transition:
+            transform 0.2s ease-out,
+            color 0.2s ease-out;
+    }
+
+    .tag-icon {
+        font-size: 1.25em;
+    }
+
+    .tag-icon::part(svg) {
+        stroke-width: 2;
+    }
+
     .combobox {
         block-size: var(--terra-block-size, 2.25rem);
         flex: 1 1 auto;
@@ -57,6 +90,7 @@ export default css`
         transition:
             background-color 0.2s ease,
             border-color 0.2s ease;
+        max-inline-size: 100%;
     }
 
     .combobox::placeholder {


### PR DESCRIPTION
This PR builds on the UX improvements for the Time Series component DSL page info, changing the combobox to act more like [the chosen jQuery plugin](https://harvesthq.github.io/chosen/).

To test, please run `npm start` and use the Time Series component to test the Variable Combobox. Within Time Series, you can set `useTags` to false to see the Variable Combobox's behavior without "tags".