### PR TITLE
feature: point Giovanni urls to Lambdas

### DIFF
--- a/src/components/map/leaflet-utils.ts
+++ b/src/components/map/leaflet-utils.ts
@@ -310,7 +310,7 @@ export class Leaflet implements Map {
 
     async fetchSelectedShape(query: any) {
         const url = new URL(
-            'https://windmill-load-balancer-641499207.us-east-1.elb.amazonaws.com/api/r/giovanni/geojson'
+            'https://pzdypgyqo6.execute-api.us-east-1.amazonaws.com/default/giovanni-geojson'
         )
 
         // Assuming the query is formatted as 'key=value'

--- a/src/components/map/map.controller.ts
+++ b/src/components/map/map.controller.ts
@@ -1,6 +1,9 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit'
 import type TerraMap from './map.js'
 
+const SHAPE_FILES_ENDPOINT =
+    'https://5ejg1qg7s4.execute-api.us-east-1.amazonaws.com/default/giovanni-shape-files'
+
 export class MapController implements ReactiveController {
     private host: ReactiveControllerHost & TerraMap
 
@@ -17,12 +20,9 @@ export class MapController implements ReactiveController {
     }
 
     private async getShapeFiles() {
-        const data = await fetch(
-            'https://windmill-load-balancer-641499207.us-east-1.elb.amazonaws.com/api/r/giovanni/shape-files',
-            {
-                mode: 'cors',
-            }
-        )
+        const data = await fetch(SHAPE_FILES_ENDPOINT, {
+            mode: 'cors',
+        })
 
         const listOfShapes = await data.json()
 


### PR DESCRIPTION
Data Rods has been using APIs hosted on Windmill, those were meant to be temporary to get the MVP rolled out. This PR points Data Rods to Lambda based APIs