### PR TITLE
feature: add TTL to time series cache

### DIFF
--- a/src/components/time-series/time-series.controller.ts
+++ b/src/components/time-series/time-series.controller.ts
@@ -8,6 +8,7 @@ import {
     IndexedDbStores,
     getDataByKey,
     storeDataByKey,
+    deleteDataByKey,
 } from '../../internal/indexeddb.js'
 import type {
     TimeSeriesData,
@@ -27,6 +28,7 @@ import type { SubsetJobStatus } from '../../data-services/types.js'
 
 const NUM_DATAPOINTS_TO_WARN_USER = 50000
 const REFRESH_HARMONY_DATA_INTERVAL = 2000
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
 const endpoint =
     'https://8weebb031a.execute-api.us-east-1.amazonaws.com/SIT/timeseries-no-user'
@@ -129,8 +131,11 @@ export class TimeSeriesController {
                 endDate,
                 new Date(existingTerraData.startDate),
                 new Date(existingTerraData.endDate)
-            )
+            ) &&
+            this.#isCacheValid(existingTerraData)
         ) {
+            console.log('Returning existing data from cache ', this.getCacheKey())
+
             // already have the data downloaded!
             return this.#getDataInRange(existingTerraData)
         }
@@ -203,6 +208,7 @@ export class TimeSeriesController {
                     metadata: consolidatedResult.metadata,
                     data: sortedData,
                     environment: this.host.environment,
+                    cachedAt: new Date().getTime(),
                 }
             )
         }
@@ -211,6 +217,26 @@ export class TimeSeriesController {
             metadata: consolidatedResult.metadata,
             data: allData,
         })
+    }
+
+    /**
+     * Checks if cached data is still valid (not expired)
+     */
+    #isCacheValid(existingData: VariableDbEntry): boolean {
+        // If cachedAt is not present (backward compatibility), consider it expired
+        if (!existingData.cachedAt) {
+            this.clearExpiredCache()
+            return false
+        }
+
+        const now = new Date().getTime()
+        const cacheIsExpired = now - existingData.cachedAt > CACHE_TTL_MS
+
+        if (cacheIsExpired) {
+            this.clearExpiredCache()
+        }
+
+        return !cacheIsExpired
     }
 
     /**
@@ -542,6 +568,26 @@ export class TimeSeriesController {
     confirmDataPointWarning() {
         this.#userConfirmedWarning = true
         this.host.showDataPointWarning = false
+    }
+
+    /**
+     * Clears expired cache entries for the current cache key
+     */
+    async clearExpiredCache() {
+        try {
+            const cacheKey = this.getCacheKey()
+            const existingData = await getDataByKey<VariableDbEntry>(
+                IndexedDbStores.TIME_SERIES,
+                cacheKey
+            )
+
+            if (existingData && !this.#isCacheValid(existingData)) {
+                await deleteDataByKey(IndexedDbStores.TIME_SERIES, cacheKey)
+                console.log(`Cleared expired cache for key: ${cacheKey}`)
+            }
+        } catch (error) {
+            console.warn('Error clearing expired cache:', error)
+        }
     }
 
     #getDataService() {

--- a/src/components/time-series/time-series.types.ts
+++ b/src/components/time-series/time-series.types.ts
@@ -12,6 +12,8 @@ export type VariableDbEntry = TimeSeriesData & {
     key: string
     /** environment used when fetching the data */
     environment?: string
+    /** timestamp when the data was cached */
+    cachedAt: number
 }
 
 export type TimeSeriesData = {

--- a/src/internal/indexeddb.ts
+++ b/src/internal/indexeddb.ts
@@ -47,3 +47,9 @@ export function storeDataByKey<T>(store: IndexedDbStores, key: string, data: T) 
         })
     })
 }
+
+export function deleteDataByKey(store: IndexedDbStores, key: string) {
+    return withDb(async db => {
+        await db.delete(store, key)
+    })
+}


### PR DESCRIPTION
Adds TTL to the time series cache.

Currently, if you load a point based or area averaged time series, a cache entry is created in IndexedDB in your browser. That cache entry stays there until you clear it.

This PR adds a 24 hour cache limit. At which point we will refetch the time series